### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/commit-pr.yml
+++ b/.github/workflows/commit-pr.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.1
 
       - name: Create Branch
         run: |
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get token from github app
         id: github-app
-        uses: getsentry/action-github-app-token@v2
+        uses: getsentry/action-github-app-token@v3.0.0
         with:
           app_id: ${{ vars.GH_APPLICATION_ID }}
           private_key: ${{ secrets.GH_APPLICATION_KEY }}

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.LEWISM20_GH_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.1](https://github.com/actions/checkout/releases/tag/v4.2.1)** on 2024-10-07T16:44:53Z
* **[getsentry/action-github-app-token](https://github.com/getsentry/action-github-app-token)** published a new release **[v3.0.0](https://github.com/getsentry/action-github-app-token/releases/tag/v3.0.0)** on 2024-02-02T00:03:38Z
