### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/commit-pr.yml
+++ b/.github/workflows/commit-pr.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
 
       - name: Create Branch
         run: |
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get token from github app
         id: github-app
-        uses: getsentry/action-github-app-token@v2
+        uses: getsentry/action-github-app-token@a0061014b82a6a5d6aeeb3b824aced47e3c3a7ef
         with:
           app_id: ${{ vars.GH_APPLICATION_ID }}
           private_key: ${{ secrets.GH_APPLICATION_KEY }}
@@ -52,7 +52,7 @@ jobs:
           echo "PR_URL=${pr_url}" >> "$GITHUB_ENV"
 
       - name: auto approve
-        uses: matt-lewis-testing-org/approve-and-merge/.github/actions/auto-approve-pr@main
+        uses: matt-lewis-testing-org/approve-and-merge/.github/actions/auto-approve-pr@9db78c29538058ce6685527f45073fb6d47d3f4b
         with:
           github-token: ${{ steps.github-app.outputs.token }}
           pr-url: ${{ env.PR_URL }}

--- a/.github/workflows/dependabot-example.yml
+++ b/.github/workflows/dependabot-example.yml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: output test
-      uses: matt-lewis-testing-org/reusable-actions/.github/actions/test-action@cb79f4bbdd89c590967d2299e0a6b4da84e585b6
+      uses: matt-lewis-testing-org/reusable-actions/.github/actions/test-action@c1443cd5d77abfa95cf635f43730d12e95950431

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ inputs.gh_token }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[matt-lewis-testing-org/reusable-actions](https://github.com/matt-lewis-testing-org/reusable-actions)** added a new **[commit](https://github.com/matt-lewis-testing-org/reusable-actions/commit/c1443cd5d77abfa95cf635f43730d12e95950431)** to **[main](https://github.com/matt-lewis-testing-org/reusable-actions/tree/main)** branch on 2024-10-10T18:20:45Z
* **[getsentry/action-github-app-token](https://github.com/getsentry/action-github-app-token)** added a new **[commit](https://github.com/getsentry/action-github-app-token/commit/a0061014b82a6a5d6aeeb3b824aced47e3c3a7ef)** to **[main](https://github.com/getsentry/action-github-app-token/tree/main)** branch on 2024-09-05T23:07:33Z
* **[actions/checkout](https://github.com/actions/checkout)** added a new **[commit](https://github.com/actions/checkout/commit/eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871)** to **[main](https://github.com/actions/checkout/tree/main)** branch on 2024-10-07T16:38:04Z
* **[matt-lewis-testing-org/approve-and-merge](https://github.com/matt-lewis-testing-org/approve-and-merge)** added a new **[commit](https://github.com/matt-lewis-testing-org/approve-and-merge/commit/9db78c29538058ce6685527f45073fb6d47d3f4b)** to **[main](https://github.com/matt-lewis-testing-org/approve-and-merge/tree/main)** branch on 2024-10-10T16:15:09Z
